### PR TITLE
Add autofocus attribute to the first element if autofocus is true

### DIFF
--- a/resources/views/components/otp-input.blade.php
+++ b/resources/views/components/otp-input.blade.php
@@ -106,6 +106,7 @@
                 >
                     <input
                         {{$isDisabled ? 'disabled' : ''}}
+                        {{$loop->first && $isAutofocused ? 'autofocus' : ''}}
                         type="{{$inputType}}"
                         maxlength="1"
                         x-ref="{{$column}}"


### PR DESCRIPTION
Salaam @hasan-ahani

The current JS method for focusing the element doesn't work in some situations and creates accessibility issues.
Sometimes I get this in the console:
```
Autofocus processing was blocked because a document already has a focused element.
```
And it won't work inside a Filament `Wizard` because they will check for `autofocus` attributes on child elements of a `Step`.

This PR fixes the issue by adding `autofocus` to the first element if `autofocus` is set to true on the component.